### PR TITLE
Rename v1 driver name

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -41,7 +41,7 @@ var (
 )
 
 func init() {
-	sql.Register("clickhouse", &bootstrap{})
+	sql.Register("clickhouse-v1", &bootstrap{})
 	go func() {
 		for tick := time.Tick(time.Second); ; {
 			select {


### PR DESCRIPTION
Rename v1 driver name to "clickhouse-v1" so that we can import both the v1 and v2 driver at the same time.